### PR TITLE
fix: Sentinel 2 Data Access

### DIFF
--- a/src/pixelverse/download/sentinel2.py
+++ b/src/pixelverse/download/sentinel2.py
@@ -79,7 +79,6 @@ def get_s2_times_series(
             "blue",
             "green",
             "red",
-            "red",
             "rededge1",
             "rededge2",
             "rededge3",


### PR DESCRIPTION
allow for data access that spans multiple sentinel MGRS tiles, takes the mean for lowest cloud cover tiles that cover user input area. 

Tests will be added in follow up PR. 