### PR TITLE
feat: Fill Missing S2 Time Series with Previous Month's data

### DIFF
--- a/src/pixelverse/download/sentinel2.py
+++ b/src/pixelverse/download/sentinel2.py
@@ -123,7 +123,7 @@ def fill_missing_months_and_format(dset: xr.Dataset) -> xr.Dataset:
 
     existing_times = pd.DatetimeIndex(dset.time.values)
 
-    missing_months = sorted(set(range(1, 13)) - set(existing_times.month))
+    missing_months = sorted(set(range(1, 13)) - set(existing_times.month))  # type: ignore[unresolved-attribute]
 
     new_dates = pd.DatetimeIndex(
         [


### PR DESCRIPTION
addresses #9 with a simple MVP solution, if a month is too cloudy to provide S2 data a logging message is surfaced, and there's a new function (`fill_missing_months_and_format`) the user can call to complete the time series by repeating the previous' month's data. 



Other Solutions Explored: 

* Using a shorter time series - for the sample test are with a threshold of 30% cloud cover 10 out of the 12 months were able to make a composite, and 20% cloud cover 9 out of the 12 months. 


**Original embedding visualization (saw too many cloudy input images in the time series)** 
<img width="456" height="469" alt="image" src="https://github.com/user-attachments/assets/ea7c9543-ea27-458c-8af2-36eff9609368" />



**10 month embedding visualization** 
<img width="456" height="469" alt="Screenshot 2025-11-05 at 2 26 06 PM" src="https://github.com/user-attachments/assets/7a1ee4f4-565f-45cc-ab85-565e54d636e6" />


**9 month embedding visualization** 
<img width="491" height="484" alt="Screenshot 2025-11-05 at 2 25 52 PM" src="https://github.com/user-attachments/assets/21e110b1-3e49-4cd1-9f67-0175d57c908f" />


**Filled Time Series Embedding**
<img width="482" height="474" alt="Screenshot 2025-11-05 at 2 27 27 PM" src="https://github.com/user-attachments/assets/bd8f0ebb-c095-4da5-91e9-60588da0aaa4" />

Follow Up Work: 
* tests

* explore impact of S2 + S1 based embeddings instead of just using the simple s2 encoder 