### PR TITLE
feat: generate embeddings and simple quantization 

### DIFF
--- a/src/pixelverse/generate_embeddings.py
+++ b/src/pixelverse/generate_embeddings.py
@@ -105,10 +105,11 @@ def quantize_embeddings(embeddings: xr.DataArray) -> xr.Dataset:
 
     scale = (max_vals - min_vals) / 255.0
     scale = np.where(scale == 0, 1, scale)
-    offset = min_vals + (128.0 * scale)
 
-    quantized_values = np.round((embeddings.values - offset[:, None, None]) / scale[:, None, None])
-    quantized_values = np.clip(quantized_values, -128, 127).astype(np.int8)
+    quantized_values = np.round(
+        (embeddings.values - min_vals[:, None, None]) / scale[:, None, None]
+    )
+    quantized_values = np.clip(quantized_values, 0, 255).astype(np.uint8)
 
     # Create Dataset directly - most efficient
     return xr.Dataset(


### PR DESCRIPTION
This PR: 

* moves MVP function for generating embeddings into the code base from the sample notebook - note this function is not yet optimized for scale 

* includes code to quantize generated embeddings - the FTW academic team is most interested in working with uint8 data, since its smaller and will be easier for downstream use cases, especially at larger areas. 

Next Steps:
* tests 

* consider - will we want to save out scale factor at some point to facilitate de-quantizing, if that would be a common use case? 

* combine `generate_embeddings` and `quantize_embedding` into one function call with an optional boolean argument and set `quantize_embedding` to be True be default? 




float32 embeddings vs. quanitzed int8 embedding 

<img width="1278" height="1224" alt="Screenshot 2025-11-19 at 9 45 44 AM" src="https://github.com/user-attachments/assets/c5f98ec6-4414-4d1e-8a44-65b94dd345df" />


<img width="1250" height="1228" alt="Screenshot 2025-11-19 at 9 51 17 AM" src="https://github.com/user-attachments/assets/0708c834-cc7e-4d8b-9113-1296bc9b2a50" />


cc @isaaccorley 