### PR TITLE
fix: use xarray median to preserve dtype

### DIFF
--- a/src/pixelverse/download/sentinel2.py
+++ b/src/pixelverse/download/sentinel2.py
@@ -93,10 +93,12 @@ def get_s2_times_series(
             "swir22",
         ],
         resolution=10,  # 10m resolution,
+        dtype="uint16",
+        nodata=0,
     )
 
     # time dim is first day of each month that appeared in the dataset
-    dset_monthly = dset.groupby("time.month").mean()
+    dset_monthly = dset.groupby("time.month").median()
     dset_monthly["month"] = dset.time.groupby("time.month").min().values
     dset_monthly = dset_monthly.rename({"month": "time"})
 


### PR DESCRIPTION
We were getting Sentinel2 data as float64 🙀 instead of the native unint16. 
Xarray mean converts to float64, unless dtype is specified, xarray's median operation preserves the native datatype. To be explicit, we also set dtype and nodata type in the odc_stac call to be uint16

shoutout to @geospatial-jeff for the help! 