### PR TITLE
Fetch tiles across a time-series

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -8,6 +8,10 @@ icon: lucide/book-marked
 
 ::: pixelverse.download.sentinel1
 ::: pixelverse.download.sentinel2
+::: pixelverse.download.stac_to_xr
+    options:
+      members:
+      - stac_to_tiles
 
 ## Embedding creation
 

--- a/src/pixelverse/download/sentinel2.py
+++ b/src/pixelverse/download/sentinel2.py
@@ -2,12 +2,17 @@
 Retrieve and process Sentinel-2 Collection 1 Level 2A multispectral data.
 """
 
+import asyncio
 from collections import defaultdict
+from types import AsyncGeneratorType
 
 import pandas as pd
+import pystac
 import xarray as xr
 from odc.stac import stac_load
 from pystac_client import Client
+
+from pixelverse.download import stac_to_tiles
 
 
 def get_s2_time_series(
@@ -108,6 +113,53 @@ def get_s2_time_series(
     return dset_monthly
 
 
+async def get_s2_time_series_tiles(
+    items: list[pystac.Item],
+) -> AsyncGeneratorType[xr.Dataset]:
+    """
+    Yield a stack of Sentinel-2 multi-band tiles for each month of a specified year.
+
+    Calls [`stac_to_tiles`][pixelverse.download.stac_to_tiles] under the hood to do
+    multiple tile fetches asynchronously.
+
+    Parameters
+    ----------
+    items : list[pystac.Item]
+        Multiple STAC Item(s) containing one/multiple STAC Assets to read from.
+
+    Yields
+    ------
+    xr.Dataset
+        An xarray.Dataset tile containing a time-series of pixel data per band as
+        data_variables, with multiple items (at different timesteps) and bands stacked
+        into a tensor of shape (time: N, height, width).
+
+    """
+    tile_generators: list[AsyncGeneratorType[xr.Dataset]] = [
+        stac_to_tiles(item=item) for item in items
+    ]
+
+    while True:
+        async with asyncio.TaskGroup() as task_group:
+            tasks_tiles: list[asyncio.Task] = [
+                task_group.create_task(
+                    coro=anext(tile_gen),
+                )
+                for tile_gen in tile_generators
+            ]
+
+        # Get list of all TIFF tiles, i.e. multi-band Sentinel-2 images from different times
+        tiles: list[xr.Dataset] = await asyncio.gather(*tasks_tiles)
+
+        ds: xr.Dataset = xr.concat(objs=tiles, dim="time")
+        # time dim is first day of each month that appeared in the dataset
+        ds_monthly = ds.groupby("time.month").mean(dtype="uint16")
+        ds_monthly["month"] = ds.time.groupby("time.month").min().values
+        ds_monthly = ds_monthly.rename({"month": "time"})
+
+        yield ds_monthly
+
+
 def fill_missing_months_and_format(dset: xr.Dataset) -> xr.Dataset:
     """
     Fill missing months in the time series by forward filling previous data.
@@ -122,8 +174,8 @@ def fill_missing_months_and_format(dset: xr.Dataset) -> xr.Dataset:
     -------
     xr.Dataset
         An xarray Dataset wit day of year data variable added and missing months filled.
-    """
 
+    """
     # add doy variable to format for model inference
     dset["doy"] = dset.time.dt.dayofyear
 

--- a/src/pixelverse/download/stac_to_xr.py
+++ b/src/pixelverse/download/stac_to_xr.py
@@ -178,7 +178,7 @@ async def stac_to_tiles(
     ------
     xr.Dataset
         An xarray.Dataset tile containing the pixel data per band as data_variables, and
-        each band stacked in the shape of (time, height, width).
+        each band stacked in the shape of (time: 1, height, width).
 
     """
     # Loop through STAC Assets (bands)

--- a/tests/test_download.py
+++ b/tests/test_download.py
@@ -2,7 +2,8 @@
 Tests for downloading Sentinel-1 and Sentinel-2 imagery.
 """
 
-from types import AsyncGeneratorType
+import copy
+from typing import TYPE_CHECKING
 
 import affine
 import async_tiff
@@ -20,6 +21,10 @@ from pixelverse.download import (
     open_tiff,
     stac_to_tiles,
 )
+from pixelverse.download.sentinel2 import get_s2_time_series_tiles
+
+if TYPE_CHECKING:
+    from types import AsyncGeneratorType
 
 
 # %%
@@ -146,5 +151,31 @@ async def test_stac_to_tiles(stac_item):
     )
 
     # Yield second tile
+    tile = await anext(tilegen)
+    assert isinstance(tile, xr.Dataset)
+
+
+async def test_get_s2_time_series_tiles(stac_item):
+    """
+    Tests opening multiple STAC items produces xarray.Dataset time-series tiles.
+    """
+    stac_item2 = copy.deepcopy(stac_item)
+    stac_item2.properties["datetime"] = "2025-10-14T00:00:00.000000"
+    items: list[pystac.Item] = [stac_item, stac_item2]
+
+    tilegen: AsyncGeneratorType[xr.Dataset] = get_s2_time_series_tiles(items=items)
+
+    # Yield first time-series tile
+    ds: xr.Dataset = await anext(tilegen)
+    assert ds.sizes == {"x": 1024, "y": 1024, "time": 2}
+    assert set(ds.dtypes.values()) == {np.dtypes.UInt16DType()}
+    assert ds.xindexes["time"].index.to_list() == [
+        pd.Timestamp("2021-04-14 08:20:24.721000"),
+        pd.Timestamp("2025-10-14 00:00:00.000000"),
+    ]
+    assert ds.attrs["s2:processing_baseline"] == "05.00"
+    assert ds.attrs["grid:code"] == "MGRS-36MVD"
+
+    # Yield second time-series tile
     tile = await anext(tilegen)
     assert isinstance(tile, xr.Dataset)


### PR DESCRIPTION
## What I am changing
<!-- What were the high-level goals of the change? -->
- Asynchronously grab tiles from the same region at different times of the year
- Almost drop-in reimplementation of [`odc.stac.load`](https://odc-stac.readthedocs.io/en/v0.3.9/_api/odc.stac.load.html), but yielding tiles instead of the whole scene

## How I did it
<!-- How did you go about achieving these goals? Any considerations made along the way? -->
TODO:
- [x] Initial draft implementation
- [ ] Add logic to ensure always fetching from same MGRS tile
- [ ] Apply to Sentinel-1 also? (might need to think about how to make things more composable/intuitive)
- [ ] More documentation
- [ ] More integration tests

## How you can test it
<!-- How might a reviewer test your changes to verify that they work as expected? -->
- Run `uv run --group dev pytest --verbose` or check CI logs.

## Related Issues
<!-- Reference any issues that inspired this PR. Use a keyword to auto-close any issues when this PR is merged (eg "closes #1") -->
Extends #24, part of #10